### PR TITLE
Fix code scanning alert no. 1: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/ch/ivy/bb/DataService.java
+++ b/src/ch/ivy/bb/DataService.java
@@ -79,7 +79,7 @@ public class DataService {
 	public List<AnimatedDataItem> animatedItems() {
 		List<AnimatedDataItem> result = new ArrayList<AnimatedDataItem>();
 
-		var open = 100;
+		long open = 100;
 		var close = 250;
 
 		for (var i = 1; i <365; i++) {


### PR DESCRIPTION
Fixes [https://github.com/axonivy/am-charts-sample/security/code-scanning/1](https://github.com/axonivy/am-charts-sample/security/code-scanning/1)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side. In this case, we should change the type of `open` from `int` to `long` to match the return type of `Math.round`. This will prevent the implicit narrowing conversion and avoid potential information loss or overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
